### PR TITLE
Ntohll

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,19 @@
+before_script:
+    - cat /etc/*release*
+    - uname -a
+
+after_script:
+    - sudo pip install pyftpdlib tftpy sphinx
+
+prepare:
+    script:
+        - sudo apt-get update
+	- sudo apt-get install -y docker.io
+        - sudo apt-get -y install wget python-pip build-essential libtool autoconf pkg-config ethtool python-flake8 libssl-dev vim
+        - pip install --upgrade pip
+
+test:
+    script:
+        - docker build -t p4c-xdp .
+	- docker run --privileged p4c-xdp uname -a
+	- docker run --privileged -w /tmp/p4c-xdp/tests p4c-xdp ./test_iproute.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - docker build -t p4c-xdp .
 
 script:
-  - docker run -w /home/p4c/extensions/p4c-xdp/tests p4c-xdp make
+  - docker run -w /home/p4c/extensions/p4c-xdp/tests p4c-xdp ./test_iproute.sh
 
 notifications:
   email:

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV PROTOBUF_DEPS autoconf \
 		  libprotobuf-c1
 
 RUN apt-get update && apt-get install -y git curl unzip gawk libelf-dev
+RUN apt-get install -y sudo 
 
 # curl ca issue
 RUN curl http://curl.haxx.se/ca/cacert.pem | awk '{print > "cert" (1+n) ".pem"} /-----END CERTIFICATE-----/ {n++}' && c_rehash

--- a/tests/bpf_helpers.h
+++ b/tests/bpf_helpers.h
@@ -21,16 +21,21 @@ typedef unsigned int u32;
 typedef signed long long s64;
 typedef unsigned long long u64;
 
+#ifndef ___constant_swab16
 #define ___constant_swab16(x) ((__u16)(             \
     (((__u16)(x) & (__u16)0x00ffU) << 8) |          \
     (((__u16)(x) & (__u16)0xff00U) >> 8)))
+#endif
 
+#ifndef ___constant_swab32
 #define ___constant_swab32(x) ((__u32)(             \
     (((__u32)(x) & (__u32)0x000000ffUL) << 24) |        \
     (((__u32)(x) & (__u32)0x0000ff00UL) <<  8) |        \
     (((__u32)(x) & (__u32)0x00ff0000UL) >>  8) |        \
     (((__u32)(x) & (__u32)0xff000000UL) >> 24)))
+#endif
 
+#ifndef ___constant_swab64
 #define ___constant_swab64(x) ((__u64)(             \
     (((__u64)(x) & (__u64)0x00000000000000ffULL) << 56) |   \
     (((__u64)(x) & (__u64)0x000000000000ff00ULL) << 40) |   \
@@ -40,12 +45,34 @@ typedef unsigned long long u64;
     (((__u64)(x) & (__u64)0x0000ff0000000000ULL) >> 24) |   \
     (((__u64)(x) & (__u64)0x00ff000000000000ULL) >> 40) |   \
     (((__u64)(x) & (__u64)0xff00000000000000ULL) >> 56)))
+#endif
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#ifndef __constant_htonll
+#define __constant_htonll(x) (___constant_swab64((x)))
+#endif
+
+#ifndef __constnat_ntohll
+#define __constant_ntohll(x) (___constant_swab64((x)))
+#endif
 
 #define __constant_htonl(x) (___constant_swab32((x)))
 #define __constant_ntohl(x) (___constant_swab32(x))
 #define __constant_htons(x) (___constant_swab16((x)))
 #define __constant_ntohs(x) ___constant_swab16((x))
 
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+# warning "I never tested BIG_ENDIAN machine!"
+#define __constant_htonll(x) (x)
+#define __constant_ntohll(X) (x)
+#define __constant_htonl(x) (x)
+#define __constant_ntohl(x) (x)
+#define __constant_htons(x) (x)
+#define __constant_ntohs(x) (x)
+
+#else
+# error "Fix your compiler's __BYTE_ORDER__?!"
+#endif
 /* END */
 
 /* helper macro to place programs, maps, license in

--- a/tests/test_iproute.sh
+++ b/tests/test_iproute.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ex
+# test whether the system has sudo and iproute2
+ip link add dev tmp123 type dummy
+ip link show
+ip link del dev tmp123
+exit 0


### PR DESCRIPTION
xdp1.c:133:42: warning: implicit declaration of function '__constant_ntohll' is invalid in C99 [-Wimplicit-function-declaration]
        hd.ethernet.destination = (u64)((load_dword(ebpf_packetStart, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
                                         ^
xdp1.c:11:29: note: expanded from macro 'load_dword'
#define load_dword(data, b) __constant_ntohll(*(u64 *)((u8*)(data) + (b)))
                            ^
1 warning generated.
clang \
    -D__KERNEL__ -D__ASM_SYSREG_H -Wno-unused-value -Wno-pointer-sign \
    -Wno-compare-distinct-pointer-types \
    -Wno-gnu-variable-sized-type-not-at-end \
    -Wno-tautological-compare \
    -O2 -emit-llvm -g -c xdp1.c -o -| llc -march=bpf -filetype=obj -o xdp1.o
xdp1.c:133:42: warning: implicit declaration of function '__constant_ntohll' is invalid in C99 [-Wimplicit-function-declaration]
        hd.ethernet.destination = (u64)((load_dword(ebpf_packetStart, BYTES(ebpf_packetOffsetInBits)) >> 16) & EBPF_MASK(u64, 48));
                                         ^
xdp1.c:11:29: note: expanded from macro 'load_dword'
#define load_dword(data, b) __constant_ntohll(*(u64 *)((u8*)(data) + (b)))
                            ^
1 warning generated.
sudo ./bpfloader xdp1.o || true
invalid relo for insn[9].code 0x85