### PR TITLE
Update the xdp backend to conform with the ebpf backend changes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 lib/*.o
 tests/*.c
-tests/*.h
+tests/xdp*.h
 tests/*.o
 tests/bpfloader
 p4c-xdp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,6 @@ set(XDP_DRIVER ${CMAKE_CURRENT_SOURCE_DIR}/run-p4c-xdp.sh)
 
 # This file will not run the full tests, but it will attempt to compile the p4 files down to C
 set (XDP_TEST_SUITES
-  "${CMAKE_CURRENT_SOURCE_DIR}/tests/*.p4"
+  "${CMAKE_CURRENT_SOURCE_DIR}/tests/xdp*.p4"
   )
 p4c_add_tests("xdp" ${XDP_DRIVER} ${XDP_TEST_SUITES} "")

--- a/target.cpp
+++ b/target.cpp
@@ -22,54 +22,14 @@ void XdpTarget::emitIncludes(Util::SourceCodeBuilder* builder) const {
     builder->append(
         "#define KBUILD_MODNAME \"xdptest\"\n"
         "#include <linux/bpf.h>\n"
-        "#include \"bpf_helpers.h\"\n"
-        "\n"
-        "#define load_byte(data, b)  (*(((u8*)(data)) + (b)))\n"
-        "#define load_half(data, b) __constant_ntohs(*(u16 *)((u8*)(data) + (b)))\n"
-        "#define load_word(data, b) __constant_ntohl(*(u32 *)((u8*)(data) + (b)))\n"
-	"#define load_dword(data, b) __constant_ntohl(*(u64 *)((u8*)(data) + (b)))\n"
-        "#define htonl(d) __constant_htonl(d)\n"
-        "#define htons(d) __constant_htons(d)\n");
+        "#include \"ebpf_xdp.h\"\n"
+        "\n");
 }
 
 void XdpTarget::emitMain(Util::SourceCodeBuilder* builder,
                          cstring functionName,
                          cstring argName) const {
     builder->appendFormat("int %s(struct xdp_md* %s)", functionName, argName);
-}
-
-void XdpTarget::emitTableDecl(Util::SourceCodeBuilder* builder,
-                              cstring tblName, bool isHash,
-                              cstring keyType, cstring valueType,
-                              unsigned size) const {
-    builder->emitIndent();
-    builder->appendFormat("struct bpf_map_def SEC(\"maps\") %s = ", tblName);
-    builder->blockStart();
-    builder->emitIndent();
-    builder->append(".type = ");
-    if (isHash)
-        builder->appendLine("BPF_MAP_TYPE_HASH,");
-    else
-        builder->appendLine("BPF_MAP_TYPE_ARRAY,");
-
-    builder->emitIndent();
-    builder->appendFormat(".key_size = sizeof(%s), ", keyType);
-    builder->newline();
-
-    builder->emitIndent();
-    builder->appendFormat(".value_size = sizeof(%s), ", valueType);
-    builder->newline();
-
-    builder->emitIndent();
-    builder->appendFormat(".pinning = 2, /* PIN_GLOBAL_NS */");
-    builder->newline();
-
-    builder->emitIndent();
-    builder->appendFormat(".max_entries = %d, ", size);
-    builder->newline();
-
-    builder->blockEnd(false);
-    builder->endOfStatement(true);
 }
 
 }  // namespace XDP

--- a/target.h
+++ b/target.h
@@ -31,9 +31,9 @@ class XdpTarget : public EBPF::KernelSamplesTarget {
                   cstring argName) const override;
     cstring dataOffset(cstring base) const override
     { return cstring("((void*)(long)")+ base + "->data)"; }
-    void emitTableDecl(Util::SourceCodeBuilder* builder,
-                       cstring tblName, bool isHash,
-                       cstring keyType, cstring valueType, unsigned size) const override;
+    //void emitTableDecl(Util::SourceCodeBuilder* builder,
+     //                  cstring tblName, bool isHash,
+     //                  cstring keyType, cstring valueType, unsigned size) const override;
     cstring dataEnd(cstring base) const override
     { return cstring("((void*)(long)")+ base + "->data_end)"; }
     void emitCodeSection(Util::SourceCodeBuilder* builder, cstring) const override

--- a/target.h
+++ b/target.h
@@ -31,9 +31,6 @@ class XdpTarget : public EBPF::KernelSamplesTarget {
                   cstring argName) const override;
     cstring dataOffset(cstring base) const override
     { return cstring("((void*)(long)")+ base + "->data)"; }
-    //void emitTableDecl(Util::SourceCodeBuilder* builder,
-     //                  cstring tblName, bool isHash,
-     //                  cstring keyType, cstring valueType, unsigned size) const override;
     cstring dataEnd(cstring base) const override
     { return cstring("((void*)(long)")+ base + "->data_end)"; }
     void emitCodeSection(Util::SourceCodeBuilder* builder, cstring) const override


### PR DESCRIPTION
This pull request updates the xdp backend slightly to port it to the p4c-ebpf compiler changes.
bpf_helpers.h was renamed to ebpf_xdp.h to confirm to the target naming convention.
target.cpp got slightly updated and several functionalities got moved to the ebpf_xdp.h file.
CMakeLists.txt got update to remove the always failing ebpf_headers.p4 test. This file is not standalone and thus does not compile.